### PR TITLE
SCLNG-1642 Angular 22 support

### DIFF
--- a/packages/core/typings/progress.core.d.ts
+++ b/packages/core/typings/progress.core.d.ts
@@ -4,7 +4,7 @@
  * Definitions by: egarcia, Traveleye, anikumar
  */
 
-export module progress {
+export namespace progress {
 
     export class data {
 
@@ -47,7 +47,7 @@ export module progress {
         name?: String
     }
 
-    export module data {
+    export namespace data {
 
         // Constants for progress.data.Session
         export class Session {

--- a/typings/progress.all.d.ts
+++ b/typings/progress.all.d.ts
@@ -4,7 +4,7 @@
  * Definitions by: egarcia, Traveleye, anikumar
  */
 
-export module progress {
+export namespace progress {
 
     export class data {
 
@@ -47,7 +47,7 @@ export module progress {
         name?: String
     }
 
-    export module data {
+    export namespace data {
 
         // Constants for progress.data.Session
         export class Session {


### PR DESCRIPTION
## Summary
- Update JSDO typings to use namespace instead of module for TypeScript 6 compatibility as part of Angular 22 support (SCLNG-1642).

## Test plan
- [ ] Verify JSDO builds and typings resolve under TypeScript 6 / Angular 22 toolchain