### PR TITLE
SCLNG-1376: expose dataset relations via public JSTableRef API

### DIFF
--- a/src/progress.js
+++ b/src/progress.js
@@ -225,6 +225,31 @@ var progress = typeof progress === 'undefined' ? {} : progress;
             }
         );
 
+        Object.defineProperty(
+            this,
+            "parentName",
+            {
+                get: function () {
+                    return this._parent || null;
+                },
+                enumerable: true
+            }
+        );
+
+        Object.defineProperty(
+            this,
+            "relationFields",
+            {
+                get: function () {
+                    // _relationship holds the parent/child data-relation field pairs
+                    // ({ parentFieldName, childFieldName }); it is only populated on
+                    // child buffers, so root/parent tables return an empty array.
+                    return this._relationship ? this._relationship.slice() : [];
+                },
+                enumerable: true
+            }
+        );
+
         // record is used to represent the current record for a table reference
         this.record = null;
 

--- a/typings/progress.all.d.ts
+++ b/typings/progress.all.d.ts
@@ -475,6 +475,14 @@ export namespace progress {
             ValidateData(args?: { plcParameter: any }): JSDORequest;
         }
 
+        /**
+         * A parent/child data-relation field pair, as defined in the JSDO catalog.
+         */
+        interface JSRelationField {
+            parentFieldName: string;
+            childFieldName: string;
+        }
+
         export class JSTableRef implements IJSTableRef, IJSRecord, ISubscribe {
 
             record: JSRecord;
@@ -488,6 +496,18 @@ export namespace progress {
              * Indicates whether the table reference is a root table in the JSDO catalog relationship graph.
              */
             readonly isRootTable: boolean;
+
+            /**
+             * The name of this table reference's parent table in the JSDO catalog
+             * relationship graph, or null when this is a root table.
+             */
+            readonly parentName: string | null;
+
+            /**
+             * The parent/child data-relation field pairs relating this table reference
+             * to its parent table in the JSDO catalog. Empty for root tables.
+             */
+            readonly relationFields: JSRelationField[];
 
             /**
              * Returns the table name for the specified table reference in the JSDO
@@ -1191,6 +1211,8 @@ export namespace progress {
             getErrors(): any;
             primaryKeyFields: string[];
             readonly isRootTable?: boolean;
+            readonly parentName?: string | null;
+            readonly relationFields?: JSRelationField[];
         }
 
         interface IJSRecord {


### PR DESCRIPTION
Adds a public, typed way to read a table's parent/child data-relation field pairs from the JSDO catalog, so consumers no longer reach into private `_buffers` / `_relationship`.

## What changed
- New public getters on `progress.data.JSTableRef` (mirroring `isRootTable`):
  - `parentName`: the table's parent table in the catalog relationship graph, or null for a root table.
  - `relationFields`: the `{ parentFieldName, childFieldName }` pairs relating this table to its parent (empty for root tables).
- New `JSRelationField` typing in `typings/progress.all.d.ts`.
- Source files only; the generated bundles under `lib/` and `packages/` are produced by the build.

## Consumed by
consultingwerkdev/webng-smartcomponentlibraryng PR (feature/SCLNG-1376): uses `relationFields` to derive view-table foreign fields for the GetInitialValues request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
